### PR TITLE
Improve bad performance

### DIFF
--- a/Sources/Canvas.swift
+++ b/Sources/Canvas.swift
@@ -227,11 +227,17 @@ public class Canvas: UIView {
             for renderable in renderables {
                 renderable.draw(context: context)
             }
+        } else {
+            print("Couldn't get context")
         }
         
         bufferImage =  UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         flattenIndex = scene.count
+        
+        if (bufferImage == nil) {
+            print("Couldn't create bufferImage")
+        }
     }
     
     private var drawBounds : CGRect {

--- a/Sources/Canvas.swift
+++ b/Sources/Canvas.swift
@@ -133,6 +133,8 @@ public class Canvas: UIView {
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         
+        layer.drawsAsynchronously = true
+        
         configureGestureRecognizers()
     }
     

--- a/Sources/Canvas.swift
+++ b/Sources/Canvas.swift
@@ -149,9 +149,12 @@ public class Canvas: UIView {
         
         if let bufferImage = bufferImage {
             bufferImage.draw(at: CGPoint.zero)
+        } else {
+            flatten()
+            bufferImage?.draw(at: CGPoint.zero)
         }
         
-        for renderable in scene {
+        for renderable in scene.suffix(from: flattenIndex) {
             renderable.draw(context: context)
         }
     }
@@ -227,17 +230,11 @@ public class Canvas: UIView {
             for renderable in renderables {
                 renderable.draw(context: context)
             }
-        } else {
-            print("Couldn't get context")
         }
         
         bufferImage =  UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         flattenIndex = scene.count
-        
-        if (bufferImage == nil) {
-            print("Couldn't create bufferImage")
-        }
     }
     
     private var drawBounds : CGRect {

--- a/Sources/Canvas.swift
+++ b/Sources/Canvas.swift
@@ -93,6 +93,7 @@ public class Canvas: UIView {
                 image.sizeToFit(inRect: bounds)
                 image.selectable = false
                 scene = [image]
+                unflatten()
                 referenceObject = image
                 delegate?.canvasDidChange(self)
                 setNeedsDisplay()
@@ -175,8 +176,7 @@ public class Canvas: UIView {
         guard !sceneExcludingReferenceObject.isEmpty else { return }
         
         if flattenIndex == scene.count {
-            bufferImage = nil
-            flattenIndex = 0
+            unflatten()
         } 
         
         scene.removeLast()
@@ -199,8 +199,7 @@ public class Canvas: UIView {
         if let index = scene.index(where: { $0 === newSelection }) {
             scene.remove(at: index)
             scene.append(newSelection)
-            flattenIndex = 0
-            bufferImage = nil
+            unflatten()
         }
         
         return selection
@@ -209,6 +208,11 @@ public class Canvas: UIView {
     private func pickObject(at position: CGPoint) -> Editable? {
         let editables = scene.flatMap({ $0 as? Editable })
         return editables.reversed().first(where: { $0.selectable && $0.bounds.contains(position) })
+    }
+    
+    private func unflatten() {
+        flattenIndex = 0
+        bufferImage = nil
     }
     
     private func flatten() {

--- a/Sources/Canvas.swift
+++ b/Sources/Canvas.swift
@@ -147,11 +147,12 @@ public class Canvas: UIView {
     override public func draw(_ rect: CGRect) {
         guard let context = UIGraphicsGetCurrentContext() else { return }
         
+        if (flattenIndex == 0 && referenceObject != nil) {
+            flatten()
+        }
+        
         if let bufferImage = bufferImage {
             bufferImage.draw(at: CGPoint.zero)
-        } else {
-            flatten()
-            bufferImage?.draw(at: CGPoint.zero)
         }
         
         for renderable in scene.suffix(from: flattenIndex) {

--- a/Sources/UIImage+Trimmed.swift
+++ b/Sources/UIImage+Trimmed.swift
@@ -54,7 +54,7 @@ public extension UIImage {
                 pixelData = pixelData.advanced(by: alignment)
             }
             
-            nonAlphaBounds = CGRect(x: Double(minX) / 2.0, y: Double(minY) / 2.0, width: Double(maxX - minX) / 2.0, height: Double(maxY - minY) / 2.0)
+            nonAlphaBounds = CGRect(x: CGFloat(minX) / scale, y: CGFloat(minY) / scale, width: CGFloat(maxX - minX) / scale, height: CGFloat(maxY - minY) / scale)
         }
         
         UIGraphicsEndImageContext()


### PR DESCRIPTION
Performance was really bad on iPhone 7 (plus)

This was due to its camera creating bigger images which are more expensive to draw. The solution is to flatten (downsize) the image sketch image to the viewport. We also had a bug which caused us to re-drawing the entire scene on each update even if we had flattened the scene.

This also contains a fix for alpha trimming on plus devices which have `scale = 3`