### PR TITLE
[Chore] Migrate to Xcode 11.3

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "wireapp/ios-snapshot-test-case" "4.0.0-xcode_10_2"
+github "wireapp/ios-snapshot-test-case" "6.2.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "wireapp/ios-snapshot-test-case" "4.0.0-xcode_10_2"
+github "wireapp/ios-snapshot-test-case" "6.2.0"

--- a/Resources/Configurations/zmc-config/project-common.xcconfig
+++ b/Resources/Configurations/zmc-config/project-common.xcconfig
@@ -53,7 +53,7 @@ DYLIB_CURRENT_VERSION = $(CURRENT_PROJECT_VERSION)
 
 // Swift
 //
-SWIFT_VERSION = 5.0
+SWIFT_VERSION = 5.1
 ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 SWIFT_COMPILATION_MODE = wholemodule
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @loader_path/Frameworks @loader_path/../Frameworks @executable_path/Frameworks @executable_path/../Frameworks

--- a/Resources/Configurations/zmc-config/project-common.xcconfig
+++ b/Resources/Configurations/zmc-config/project-common.xcconfig
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#include "warnings.xcconfig"
+#include "./warnings.xcconfig"
 #include "../version.xcconfig"
 
 // Architectures

--- a/Sources/Canvas.swift
+++ b/Sources/Canvas.swift
@@ -222,7 +222,7 @@ public class Canvas: UIView {
         }
         
         // move object to top
-        if let index = scene.index(where: { $0 === newSelection }) {
+        if let index = scene.firstIndex(where: { $0 === newSelection }) {
             scene.remove(at: index)
             scene.append(newSelection)
             unflatten()

--- a/WireCanvas.xcodeproj/project.pbxproj
+++ b/WireCanvas.xcodeproj/project.pbxproj
@@ -252,7 +252,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0800;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = "Wire GmbH";
 				TargetAttributes = {
 					165EA0C21DB67C3B008ECC60 = {

--- a/WireCanvas.xcodeproj/xcshareddata/xcschemes/WireCanvas.xcscheme
+++ b/WireCanvas.xcodeproj/xcshareddata/xcschemes/WireCanvas.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "165EA0C21DB67C3B008ECC60"
+            BuildableName = "WireCanvas.framework"
+            BlueprintName = "WireCanvas"
+            ReferencedContainer = "container:WireCanvas.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "165EA0C21DB67C3B008ECC60"
-            BuildableName = "WireCanvas.framework"
-            BlueprintName = "WireCanvas"
-            ReferencedContainer = "container:WireCanvas.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -77,8 +75,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
   - repository: wire-ios-shared-resources
     type: github
     name: wireapp/wire-ios-shared-resources
-    ref: refs/heads/master # Branch to fetch the jobs template from
+    ref: refs/heads/chore/xcode11.3 # Branch to fetch the jobs template from
     endpoint: wireapp
 
 trigger:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
   - repository: wire-ios-shared-resources
     type: github
     name: wireapp/wire-ios-shared-resources
-    ref: refs/heads/chore/xcode11.3 # Branch to fetch the jobs template from
+    ref: refs/heads/master # Branch to fetch the jobs template from
     endpoint: wireapp
 
 trigger:


### PR DESCRIPTION
## What's new in this PR?

This PR includes changes to migrate from Xcode 10.2.3 to Xcode 11.3. Changes include:

- update to recommended project settings
- fixed renaming warning

### Needs Release With

- [x] https://github.com/wireapp/wire-ios-shared-resources/pull/39

### To Do

- [x] Unpin azure pipeline

### Notes

Zero build warnings 🎉 
