### PR TITLE
[Fix] Don't run system gesture recognizers inside the Canvas

### DIFF
--- a/Sources/Canvas.swift
+++ b/Sources/Canvas.swift
@@ -343,6 +343,10 @@ public class Canvas: UIView {
         }
     }
     
+    public override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return gestureRecognizers?.contains(gestureRecognizer) ?? false
+    }
+    
     // MARK - Touch handling
     
     override public func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Canvas does not work correctly when displayed as a iOS 13 page sheet.

### Causes

Page sheet gesture recognizer is interfering with the canvas drawing.

### Solutions

Only allow our own gesture recognizers to run inside the Canvas.
