### PR TITLE
fix: SwiftLint warnings for multiple rules & add support for Apple Silicon Brew Directory

### DIFF
--- a/Sources/Canvas.swift
+++ b/Sources/Canvas.swift
@@ -51,9 +51,7 @@ struct Orientation {
     var rotation: CGFloat
 
     static var standard: Orientation {
-        get {
-            return Orientation(scale: 1, position: CGPoint.zero, rotation: 0)
-        }
+        return Orientation(scale: 1, position: CGPoint.zero, rotation: 0)
     }
 }
 
@@ -274,7 +272,6 @@ public class Canvas: UIView {
     }
 
     private var drawBounds: CGRect {
-        get {
             var bounds = scene.first?.bounds ?? CGRect.zero
 
             for renderable in scene.suffix(from: 1) {
@@ -282,12 +279,10 @@ public class Canvas: UIView {
             }
 
             return bounds
-        }
     }
 
     /// Return an image of the canvas content.
     public var trimmedImage: UIImage? {
-        get {
             let scaleFactor: CGFloat = 2.0 // We want to render with 2x scale factor also on non-retina devices
             var image: UIImage?
             selection?.selected = false
@@ -339,7 +334,6 @@ public class Canvas: UIView {
             }
 
             return image
-        }
     }
 
     public override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {

--- a/Sources/Canvas.swift
+++ b/Sources/Canvas.swift
@@ -19,39 +19,38 @@
 import UIKit
 import QuartzCore
 
-
 public enum EditingMode {
     case draw
     case edit
 }
 
-protocol Renderable : class {
-    
-    var bounds : CGRect { get }
-    
-    func draw(context : CGContext)
-    
+protocol Renderable: class {
+
+    var bounds: CGRect { get }
+
+    func draw(context: CGContext)
+
 }
 
-protocol Editable : Renderable {
-    
-    var selected : Bool { get set }
-    var selectedView : UIView { get }
-    var selectable : Bool { get }
-    var transform : CGAffineTransform { get }
-    var size : CGSize  { get }
-    var scale : CGFloat { get set }
-    var position : CGPoint { get set }
-    var rotation : CGFloat { get set }
+protocol Editable: Renderable {
+
+    var selected: Bool { get set }
+    var selectedView: UIView { get }
+    var selectable: Bool { get }
+    var transform: CGAffineTransform { get }
+    var size: CGSize { get }
+    var scale: CGFloat { get set }
+    var position: CGPoint { get set }
+    var rotation: CGFloat { get set }
 }
 
 struct Orientation {
-    
-    var scale : CGFloat
-    var position : CGPoint
-    var rotation : CGFloat
-    
-    static var standard : Orientation {
+
+    var scale: CGFloat
+    var position: CGPoint
+    var rotation: CGFloat
+
+    static var standard: Orientation {
         get {
             return Orientation(scale: 1, position: CGPoint.zero, rotation: 0)
         }
@@ -59,33 +58,33 @@ struct Orientation {
 }
 
 public protocol CanvasDelegate {
-    
-    func canvasDidChange(_ canvas : Canvas)
-    
+
+    func canvasDidChange(_ canvas: Canvas)
+
 }
 
 public class Canvas: UIView {
-    
-    fileprivate let minimumScale : CGFloat = 0.5
-    fileprivate let maximumScale : CGFloat = 10.0
-    
-    public var delegate : CanvasDelegate? = nil
-    
+
+    fileprivate let minimumScale: CGFloat = 0.5
+    fileprivate let maximumScale: CGFloat = 10.0
+
+    public var delegate: CanvasDelegate?
+
     /// Defines the apperance of the brush strokes when drawing
     public var brush = Brush(size: 2, color: .black)
-    
+
     /// Active mode of the canvas. See `EditingMode` for possible values.
-    public var mode : EditingMode = .draw {
+    public var mode: EditingMode = .draw {
         didSet {
             selection = nil
             gestureRecognizers?.forEach({ $0.isEnabled = mode == .edit })
             setNeedsDisplay()
         }
     }
-    
+
     /// An image on which you can draw on top.
-    public var referenceImage : UIImage? {
-        
+    public var referenceImage: UIImage? {
+
         didSet {
             if let referenceImage = referenceImage, let cgImage = referenceImage.cgImage {
                 let retinaImage = UIImage(cgImage: cgImage, scale: 2, orientation: referenceImage.imageOrientation)
@@ -100,137 +99,137 @@ public class Canvas: UIView {
             }
         }
     }
-    
+
     /// hasChanges is true if the canvas has changes which can be un done. See undo()
-    public var hasChanges : Bool {
+    public var hasChanges: Bool {
         return sceneExcludingReferenceObject.count > 0
     }
-    
-    private var scene : [Renderable] = []
-    private var bufferImage : UIImage?
-    private var selectionView : UIView?
-    private var stroke : Stroke?
-    private var referenceObject : Image?
-    private var flattenIndex : Int = 0
-    
-    fileprivate var sceneExcludingReferenceObject : [Renderable] {
+
+    private var scene: [Renderable] = []
+    private var bufferImage: UIImage?
+    private var selectionView: UIView?
+    private var stroke: Stroke?
+    private var referenceObject: Image?
+    private var flattenIndex: Int = 0
+
+    fileprivate var sceneExcludingReferenceObject: [Renderable] {
         return scene.filter({ $0 !== referenceObject })
     }
-    
-    fileprivate var selection : Editable? {
+
+    fileprivate var selection: Editable? {
         didSet {
             guard selection !== oldValue else { return }
-            
+
             selectionView?.removeFromSuperview()
             selectionView = selection?.selectedView
-            
+
             if let selectedView = selectionView {
                 addSubview(selectedView)
             }
-            
+
             oldValue?.selected = false
             selection?.selected = true
-            
+
             if let oldSelection = oldValue {
                 setNeedsDisplay(oldSelection.bounds)
             }
-            
+
             if let newSelection = selection {
                 setNeedsDisplay(newSelection.bounds)
             }
         }
     }
-    
-    fileprivate var initialOrienation : Orientation = Orientation.standard
-    
+
+    fileprivate var initialOrienation: Orientation = Orientation.standard
+
     override public init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         configureGestureRecognizers()
     }
-    
+
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        
+
         layer.drawsAsynchronously = true
-        
+
         configureGestureRecognizers()
     }
-    
+
     override public func layoutSubviews() {
         super.layoutSubviews()
-        
+
         if let referenceObject = referenceObject {
             referenceObject.sizeToFit(inRect: bounds)
         }
     }
-    
+
     override public func draw(_ rect: CGRect) {
         guard let context = UIGraphicsGetCurrentContext() else { return }
-        
-        if (flattenIndex == 0 && referenceObject != nil) {
+
+        if flattenIndex == 0 && referenceObject != nil {
             flatten(upTo: 1)
         }
-        
+
         if let bufferImage = bufferImage {
             bufferImage.draw(at: CGPoint.zero)
         }
-        
+
         for renderable in scene.suffix(from: flattenIndex) {
             renderable.draw(context: context)
         }
     }
-    
+
     public func insert(image: UIImage, at position: CGPoint) {
         let image = Image(image: image, at: position)
-        
+
         scene.append(image)
         selection = image
         setNeedsDisplay()
         delegate?.canvasDidChange(self)
     }
-    
+
     func insert(brush: Brush, at position: CGPoint) -> Stroke {
         let stroke = Stroke(at: position, brush: brush)
         scene.append(stroke)
         delegate?.canvasDidChange(self)
         return stroke
     }
-    
+
     @objc public func undo() {
         guard !sceneExcludingReferenceObject.isEmpty else { return }
-        
+
         if flattenIndex == scene.count {
             unflatten()
-        } 
-        
+        }
+
         if selection === scene.removeLast() {
             selection = nil
         }
-        
+
         setNeedsDisplay()
         delegate?.canvasDidChange(self)
     }
-    
+
     @discardableResult fileprivate func selectObject(at position: CGPoint) -> Editable? {
         let previousSelection = selection
-        
+
         selection = pickObject(at: position)
-        
+
         guard let newSelection = selection, selection !== previousSelection else {
             return selection
         }
-        
+
         // move object to top
         if let index = scene.firstIndex(where: { $0 === newSelection }) {
             scene.remove(at: index)
             scene.append(newSelection)
             unflatten()
         }
-        
+
         return selection
     }
-    
+
     private func pickObject(at position: CGPoint) -> Editable? {
         let editables = scene.compactMap({ $0 as? Editable })
         return editables.reversed().first(where: { editable in
@@ -240,142 +239,142 @@ public class Canvas: UIView {
             return bounds.contains(position)
         })
     }
-    
+
     private func unflatten() {
         flattenIndex = 0
         bufferImage = nil
     }
-    
+
     private func flatten() {
         flatten(upTo: scene.count)
     }
-    
+
     private func flatten(upTo: Int) {
         let renderables = scene.prefix(upTo: upTo).suffix(from: flattenIndex)
-        
+
         guard renderables.count > 0 else { return }
-        
+
         selection?.selected = false
         defer {
             selection?.selected = true
         }
-        
+
         UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0.0)
         bufferImage?.draw(at: CGPoint.zero)
-        
+
         if let context = UIGraphicsGetCurrentContext() {
             for renderable in renderables {
                 renderable.draw(context: context)
             }
         }
-        
+
         bufferImage =  UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         flattenIndex = upTo
     }
-    
-    private var drawBounds : CGRect {
+
+    private var drawBounds: CGRect {
         get {
             var bounds = scene.first?.bounds ?? CGRect.zero
-            
+
             for renderable in scene.suffix(from: 1) {
                 bounds = bounds.union(renderable.bounds)
             }
-            
+
             return bounds
         }
     }
-    
+
     /// Return an image of the canvas content.
-    public var trimmedImage : UIImage? {
-        get{
-            let scaleFactor : CGFloat = 2.0 // We want to render with 2x scale factor also on non-retina devices
-            var image : UIImage? = nil
+    public var trimmedImage: UIImage? {
+        get {
+            let scaleFactor: CGFloat = 2.0 // We want to render with 2x scale factor also on non-retina devices
+            var image: UIImage?
             selection?.selected = false
             defer {
                 selection?.selected = true
             }
-            
+
             if let referenceObject = referenceObject {
 
                 let drawBounds = self.bounds.intersection(self.drawBounds)
                 let renderScale = 1 / referenceObject.scale // We want to match resolution of the image we are drawing upon on
                 let renderSize = drawBounds.size.applying(CGAffineTransform(scaleX: renderScale * scaleFactor, y: renderScale * scaleFactor))
                 let renderBounds = CGRect(origin: CGPoint.zero, size: renderSize).integral.applying(CGAffineTransform(scaleX: 1 / scaleFactor, y: 1 / scaleFactor))
-                
+
                 UIGraphicsBeginImageContextWithOptions(renderBounds.size, true, scaleFactor)
-                
+
                 if let context = UIGraphicsGetCurrentContext() {
                     context.scaleBy(x: renderScale, y: renderScale)
                     context.translateBy(x: -drawBounds.origin.x, y: -drawBounds.origin.y)
-                    
+
                     UIColor.white.setFill()
                     context.fill(CGRect(origin: drawBounds.origin, size: renderBounds.size))
-                    
+
                     for renderable in scene {
                         renderable.draw(context: context)
                     }
                 }
-                
+
                 image =  UIGraphicsGetImageFromCurrentImageContext()
                 UIGraphicsEndImageContext()
             } else {
                 let drawBounds = self.bounds.intersection(self.drawBounds).integral
- 
+
                 UIGraphicsBeginImageContextWithOptions(drawBounds.size, true, scaleFactor)
-                
+
                 if let context = UIGraphicsGetCurrentContext() {
                     context.translateBy(x: -drawBounds.origin.x, y: -drawBounds.origin.y)
-                    
+
                     UIColor.white.setFill()
                     context.fill(drawBounds)
-                    
+
                     for renderable in scene {
                         renderable.draw(context: context)
                     }
                 }
-                
+
                 image =  UIGraphicsGetImageFromCurrentImageContext()
                 UIGraphicsEndImageContext()
             }
-            
+
             return image
         }
     }
-    
+
     public override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         return gestureRecognizers?.contains(gestureRecognizer) ?? false
     }
-    
-    // MARK - Touch handling
-    
+
+    // MARK: - Touch handling
+
     override public func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
-        
+
         guard mode == .draw else { return }
-        
+
         if let location = touches.first?.location(in: self) {
             let stroke = insert(brush: brush, at: location)
             setNeedsDisplay(stroke.bounds)
             self.stroke = stroke
         }
     }
-    
+
     override public func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesMoved(touches, with: event)
-        
+
         guard mode == .draw else { return }
-        
+
         if let location = touches.first?.location(in: self), let stroke = stroke {
             setNeedsDisplay(stroke.move(to: location))
         }
     }
-    
+
     override public func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesEnded(touches, with: event)
-        
+
         guard mode == .draw else { return }
-        
+
         stroke?.end()
         flatten()
         setNeedsDisplay()
@@ -383,30 +382,30 @@ public class Canvas: UIView {
 
 }
 
-extension Canvas : UIGestureRecognizerDelegate {
-    
+extension Canvas: UIGestureRecognizerDelegate {
+
     func configureGestureRecognizers() {
         let tapGestureReconizer = UITapGestureRecognizer(target: self, action: #selector(handleTapGesture))
         addGestureRecognizer(tapGestureReconizer)
-        
+
         let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture))
         addGestureRecognizer(panGestureRecognizer)
-        
+
         let pinchGestureRecognizer =  UIPinchGestureRecognizer(target: self, action: #selector(handlePinchGesture))
         addGestureRecognizer(pinchGestureRecognizer)
         pinchGestureRecognizer.delegate = self
-        
+
         let rotateGestureRecognzier = UIRotationGestureRecognizer(target: self, action: #selector(handleRotateGesture))
         rotateGestureRecognzier.delegate = self
         addGestureRecognizer(rotateGestureRecognzier)
-        
+
         gestureRecognizers?.forEach({ $0.isEnabled = mode == .edit })
     }
-    
+
     @objc public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return true
     }
-    
+
     @objc func handleTapGesture(gestureRecognizer: UITapGestureRecognizer) {
         if gestureRecognizer.state == .began && selection == nil {
             selectObject(at: gestureRecognizer.location(in: self))
@@ -414,7 +413,7 @@ extension Canvas : UIGestureRecognizerDelegate {
             selectObject(at: gestureRecognizer.location(in: self))
         }
     }
-    
+
     @objc func handlePanGesture(gestureRecognizer: UIPanGestureRecognizer) {
         switch gestureRecognizer.state {
         case .began:
@@ -428,7 +427,7 @@ extension Canvas : UIGestureRecognizerDelegate {
             break
         }
     }
-    
+
     @objc func handlePinchGesture(gestureRecognizer: UIPinchGestureRecognizer) {
         switch gestureRecognizer.state {
         case .began:
@@ -441,7 +440,7 @@ extension Canvas : UIGestureRecognizerDelegate {
             break
         }
     }
-    
+
     @objc func handleRotateGesture(gestureRecognizer: UIRotationGestureRecognizer) {
         switch gestureRecognizer.state {
         case .began:
@@ -454,5 +453,5 @@ extension Canvas : UIGestureRecognizerDelegate {
             break
         }
     }
-    
+
 }

--- a/Sources/Canvas.swift
+++ b/Sources/Canvas.swift
@@ -25,11 +25,11 @@ public enum EditingMode {
 }
 
 protocol Renderable: AnyObject {
-    
+
     var bounds: CGRect { get }
-    
-    func draw(context : CGContext)
-    
+
+    func draw(context: CGContext)
+
 }
 
 protocol Editable: Renderable {

--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -42,15 +42,11 @@ class Image: Editable {
     var imageView = UIImageView()
 
     var size: CGSize {
-        get {
-            return image.size
-        }
+        return image.size
     }
 
     var bounds: CGRect {
-        get {
-            return CGRect(x: 0, y: 0, width: size.width, height: size.height).applying(transform)
-        }
+        return CGRect(x: 0, y: 0, width: size.width, height: size.height).applying(transform)
     }
 
     var selectedView: UIView {
@@ -80,7 +76,6 @@ class Image: Editable {
     }
 
     var transform: CGAffineTransform {
-        get {
             let center = CGPoint(x: size.width / 2, y: size.height / 2)
             let toCenter = CGAffineTransform(translationX: -center.x, y: -center.y)
             let restoreCenter = CGAffineTransform(translationX: center.x, y: center.y)
@@ -89,7 +84,6 @@ class Image: Editable {
             let translate = CGAffineTransform(translationX: position.x, y: position.y)
 
             return toCenter.concatenating(scaleTransform).concatenating(rotationTransform).concatenating(restoreCenter).concatenating(translate)
-        }
     }
 
     func sizeToFit(inRect rect: CGRect) {

--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -19,44 +19,44 @@
 import Foundation
 import UIKit
 
-class Image : Editable {
-    
-    let image : UIImage
-    var scale : CGFloat {
+class Image: Editable {
+
+    let image: UIImage
+    var scale: CGFloat {
         didSet {
             updateImageTransform()
         }
     }
-    var rotation : CGFloat {
+    var rotation: CGFloat {
         didSet {
             updateImageTransform()
         }
     }
-    var position : CGPoint {
+    var position: CGPoint {
         didSet {
             updateImageTransform()
         }
     }
-    var selected : Bool
+    var selected: Bool
     var selectable = true
     var imageView = UIImageView()
-    
+
     var size: CGSize {
         get {
             return image.size
         }
     }
-    
+
     var bounds: CGRect {
         get {
             return CGRect(x: 0, y: 0, width: size.width, height: size.height).applying(transform)
         }
     }
-    
+
     var selectedView: UIView {
         return imageView
     }
-    
+
     public init(image: UIImage, at position: CGPoint) {
         self.image = image
         self.scale = 1
@@ -66,20 +66,20 @@ class Image : Editable {
         self.imageView.image = image
         self.imageView.layer.anchorPoint = CGPoint(x: 0.0, y: 0.0)
         self.imageView.sizeToFit()
-        
+
         updateImageTransform()
     }
-    
-    func draw(context : CGContext) {
+
+    func draw(context: CGContext) {
         guard !selected else { return }
-        
+
         context.saveGState()
         context.concatenate(transform)
         image.draw(at: CGPoint.zero)
         context.restoreGState()
     }
-        
-    var transform : CGAffineTransform {
+
+    var transform: CGAffineTransform {
         get {
             let center = CGPoint(x: size.width / 2, y: size.height / 2)
             let toCenter = CGAffineTransform(translationX: -center.x, y: -center.y)
@@ -87,23 +87,22 @@ class Image : Editable {
             let scaleTransform = CGAffineTransform(scaleX: scale, y: scale)
             let rotationTransform = CGAffineTransform(rotationAngle: rotation)
             let translate = CGAffineTransform(translationX: position.x, y: position.y)
-            
+
             return toCenter.concatenating(scaleTransform).concatenating(rotationTransform).concatenating(restoreCenter).concatenating(translate)
         }
     }
-    
+
     func sizeToFit(inRect rect: CGRect) {
         let scaleX = min(rect.size.width / image.size.width, 1.0)
         let scaleY = min(rect.size.height / image.size.height, 1.0)
         let center = CGPoint(x: rect.midX - size.width / 2, y: rect.midY - size.height / 2)
-        
+
         position = center
         scale = min(scaleX, scaleY)
     }
-    
+
     func updateImageTransform() {
         imageView.transform = transform
     }
-    
-    
+
 }

--- a/Sources/Stroke.swift
+++ b/Sources/Stroke.swift
@@ -46,9 +46,7 @@ class Stroke: Renderable {
     private let brush: Brush
 
     var bounds: CGRect {
-        get {
-            return bounds(from: 0)
-        }
+        return bounds(from: 0)
     }
 
     public init(at position: CGPoint, brush: Brush) {

--- a/Sources/Stroke.swift
+++ b/Sources/Stroke.swift
@@ -20,55 +20,55 @@ import Foundation
 import UIKit
 
 public struct Brush {
-    
+
     public init(size: Float, color: UIColor) {
         self.size = size
         self.color = color
     }
-    
+
     let size: Float
     let color: UIColor
-    
+
     public func change(toColor color: UIColor) -> Brush {
         return Brush(size: size, color: color)
     }
-    
+
     public func change(toSize size: Float) -> Brush {
         return Brush(size: size, color: color)
     }
-    
+
 }
 
-class Stroke : Renderable {
-    
-    private var points : [CGPoint]
+class Stroke: Renderable {
+
+    private var points: [CGPoint]
     private let minimumStrokeDistance = 0.1
-    private let brush : Brush
-    
+    private let brush: Brush
+
     var bounds: CGRect {
         get {
             return bounds(from: 0)
         }
     }
-    
+
     public init(at position: CGPoint, brush: Brush) {
         self.brush = brush
         self.points = [position]
     }
-    
+
     func move(to point: CGPoint) -> CGRect {
         guard distance(to: point) > minimumStrokeDistance else { return CGRect.zero }
-        
+
         points.append(smooth(point: point))
-        
+
         return bounds(from: max(points.count - 3, 0)) // Need to update last two segments
     }
-    
+
     func end() {
-        
+
     }
-    
-    func draw(context : CGContext) {
+
+    func draw(context: CGContext) {
         if points.count == 1, let point = points.first {
             context.setFillColor(brush.color.cgColor)
             let origin = CGPoint(x: point.x - CGFloat(brush.size / 2), y: point.y - CGFloat(brush.size / 2))
@@ -82,94 +82,93 @@ class Stroke : Renderable {
             path.stroke()
         }
     }
-    
+
     func distance(to point: CGPoint) -> Double {
         let lastPoint = points.last!
         let translation = CGPoint(x: point.x - lastPoint.x, y: point.y - lastPoint.y)
         return sqrt(Double(translation.x * translation.x + translation.y * translation.y))
     }
-    
+
     func bounds(from index: Int) -> CGRect {
         var minX = Double.infinity
         var minY = Double.infinity
         var maxX = -Double.infinity
         var maxY = -Double.infinity
-        
+
         for point in points.suffix(from: index) {
             minX = min(Double(point.x), minX)
             minY = min(Double(point.y), minY)
             maxX = max(Double(point.x), maxX)
             maxY = max(Double(point.y), maxY)
         }
-        
+
         let outset = CGFloat(-brush.size)
         return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY).insetBy(dx: outset, dy: outset)
     }
-    
+
     func interpolateLinearPath(points: [CGPoint]) -> UIBezierPath {
         let path = UIBezierPath()
         path.move(to: points.first!)
-        
+
         for point in points.dropFirst() {
             path.addLine(to: point)
         }
-        
+
         return path
     }
-    
+
     func smooth(point: CGPoint, factor: CGFloat = 0.35) -> CGPoint {
         let previous = points.last!
         return CGPoint(x: previous.x * (1 - factor) + point.x * factor,
                        y: previous.y * (1 - factor) + point.y * factor)
     }
-    
+
     func interpolateBeizerPath(points: [CGPoint]) -> UIBezierPath {
         let path = UIBezierPath()
         path.move(to: points.first!)
         path.lineWidth = CGFloat(brush.size)
-        
+
         let controlPoints = controlsPoints(points: points)
-        
+
         for i in 1..<points.count {
             path.addCurve(to: points[i], controlPoint1: controlPoints[i-1].1, controlPoint2: controlPoints[i].0)
         }
-        
-        
+
         return path
     }
-    
-    func controlsPoints(points : [CGPoint]) -> [(CGPoint, CGPoint)] {
-        
+
+    func controlsPoints(points: [CGPoint]) -> [(CGPoint, CGPoint)] {
+
         let points = [points.first!] + points + [points.last!]
-        var controlPoints : [(CGPoint, CGPoint)] = []
-        
+        var controlPoints: [(CGPoint, CGPoint)] = []
+
         for i in 1..<points.count-1 {
             let p0 = points[i-1]
             let p1 = points[i]
             let p2 = points[i+1]
-            
+
             let v0 = CGPoint(x: p1.x - p0.x, y: p1.y - p0.y)
             let v1 = CGPoint(x: p2.x - p1.x, y: p2.y - p1.y)
-            
+
             let a0 = CGPoint(x: p0.x + 0.5 * v0.x, y: p0.y + 0.5 * v0.y)
             let a1 = CGPoint(x: p1.x + 0.5 * v1.x, y: p1.y + 0.5 * v1.y)
-            
+
             let len0 = v0.x * v0.x + v0.y * v0.y
             let len1 = v1.x * v1.x + v1.y * v1.y
             let ratio =  len0 / (len0 + len1)
-            
+
             let b0 = CGPoint(x: a0.x - a1.x, y: a0.y - a1.y)
-            
+
             let d0 = CGPoint(x: b0.x * ratio, y: b0.y * ratio)
             let d1 = CGPoint(x: b0.x * (ratio - 1), y: b0.y * (ratio - 1))
-            
+
             let cp0 = CGPoint(x: p1.x + d0.x, y: p1.y + d0.y)
             let cp1 = CGPoint(x: p1.x + d1.x, y: p1.y + d1.y)
-            
+
             controlPoints.append((cp0, cp1))
         }
-        
+
         return controlPoints
     }
-    
+
 }

--- a/Sources/UIImage+Trimmed.swift
+++ b/Sources/UIImage+Trimmed.swift
@@ -20,57 +20,57 @@ import Foundation
 import UIKit
 
 public extension UIImage {
-    
-    var imageWithAlphaTrimmed : UIImage {
+
+    var imageWithAlphaTrimmed: UIImage {
         let originalSize = self.size
-        
+
         var minX = Int.max
         var maxX = Int.min
         var minY = Int.max
         var maxY = Int.min
         var nonAlphaBounds = CGRect.zero
-        var trimmedImage : UIImage = self
-        
+        var trimmedImage: UIImage = self
+
         UIGraphicsBeginImageContextWithOptions(originalSize, false, scale)
-        
+
         draw(at: CGPoint.zero)
-        
+
         if let context = UIGraphicsGetCurrentContext(), var pixelData = context.data?.assumingMemoryBound(to: UInt32.self) {
-            
+
             let alignment = (8 - (context.width % 8)) % 8
-            
+
             for y in 0..<context.height * 1 {
                 for x in 0..<context.width * 1 {
                     let alpha = UInt8((pixelData.pointee >> 24) & 255)
-                    
+
                     if alpha > 0 {
                         minX = min(x, minX)
                         maxX = max(x, maxX)
                         minY = min(y, minY)
                         maxY = max(y, maxY)
                     }
-                    
+
                     pixelData = pixelData.successor()
                 }
                 pixelData = pixelData.advanced(by: alignment)
             }
-            
+
             nonAlphaBounds = CGRect(x: CGFloat(minX) / scale, y: CGFloat(minY) / scale, width: CGFloat(maxX - minX) / scale, height: CGFloat(maxY - minY) / scale)
         }
-        
+
         UIGraphicsEndImageContext()
-        
+
         UIGraphicsBeginImageContextWithOptions(nonAlphaBounds.size, false, scale)
-        
+
         draw(at: CGPoint(x: -nonAlphaBounds.origin.x, y: -nonAlphaBounds.origin.y))
-        
+
         if let image = UIGraphicsGetImageFromCurrentImageContext() {
             trimmedImage = image
         }
-        
+
         UIGraphicsEndImageContext()
-        
+
         return trimmedImage
     }
-    
+
 }

--- a/Tests/CanvasTests.swift
+++ b/Tests/CanvasTests.swift
@@ -21,35 +21,35 @@ import FBSnapshotTestCase
 @testable import WireCanvas
 
 final class CanvasTests: FBSnapshotTestCase {
-    
+
     func testTrimmedImage_isClippedToViewport() {
         // given
         let frame = CGRect(origin: CGPoint.zero, size: CGSize(width: 375, height: 667))
         let canvas = Canvas(frame: frame)
         let image = UIImage(testImageNamed: "unsplash_small.jpg")!
-        
+
         // when placing image half way outside the viewport
         canvas.insert(image: image, at: CGPoint(x: -image.size.width / 2, y: frame.midY))
-        
+
         // then it should be clipped by the viewport
         let imageView = UIImageView(image: canvas.trimmedImage)
         FBSnapshotVerifyView(imageView)
     }
-    
+
     func testTrimmedImage_isClippedToViewport_withReferenceImage() {
         // given
         let frame = CGRect(origin: CGPoint.zero, size: CGSize(width: 375, height: 667))
         let canvas = Canvas(frame: frame)
-        
+
         canvas.referenceImage = UIImage(testImageNamed: "unsplash_matterhorn.jpg")!
         let image = UIImage(testImageNamed: "unsplash_small.jpg")!
-        
+
         // when placing image half way outside the viewport
         canvas.insert(image: image, at: CGPoint(x: -image.size.width / 2, y: frame.midY - image.size.height / 2))
-        
+
         // then it should be clipped by the viewport
         let imageView = UIImageView(image: canvas.trimmedImage)
         FBSnapshotVerifyView(imageView)
     }
-    
+
 }

--- a/Tests/TestHelper.swift
+++ b/Tests/TestHelper.swift
@@ -20,17 +20,17 @@ import Foundation
 import UIKit
 
 extension UIImage {
-    
+
     convenience init?(testImageNamed name: String) {
         func url(forTestResourceNamed name: String) -> URL? {
             let bundle = Bundle(for: CanvasTests.self)
-            return bundle.url(forResource: (name as NSString).deletingPathExtension, withExtension:(name as NSString).pathExtension)
+            return bundle.url(forResource: (name as NSString).deletingPathExtension, withExtension: (name as NSString).pathExtension)
         }
-        
+
         guard let url = url(forTestResourceNamed: name) else { return nil }
         guard let data = try? Data(contentsOf: url) else { return nil }
 
         self.init(data: data, scale: 2)
     }
-    
+
 }

--- a/WireCanvas.xcodeproj/project.pbxproj
+++ b/WireCanvas.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "# Adds support for Apple Silicon brew directory\nexport PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

#### Fixed warnings for multiple rules including: 
- **Opening Brace Spacing Violation**: Opening braces should be preceded by a single space and on the same line as the declaration. `(opening_brace)`
- **Colon Violation**: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. `(colon)`
- **Trailing Whitespace Violation**: Lines should not have trailing whitespace. `(trailing_whitespace)`
- **Implicit Getter Violation**: Computed read-only properties should avoid using the get keyword. `(implicit_getter)`

#### In addition to that:

-  I added support for Apple Silicon Brew Directory for SwiftLint

# Notes

After this PR is merged we can move to the disabled rules list.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
