### PR TITLE
fix: Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead

### DIFF
--- a/Sources/Canvas.swift
+++ b/Sources/Canvas.swift
@@ -25,7 +25,7 @@ public enum EditingMode {
     case edit
 }
 
-protocol Renderable : class {
+protocol Renderable : AnyObject {
     
     var bounds : CGRect { get }
     


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
  
----

# What's new in this PR?

fix Swift compiler warning: `Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
