### PR TITLE
fix: Swiftlint warnings for `weak_delegate`, `class_delegate_protocol` & remove a bunch of rules from the disabled rules list

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -15,9 +15,7 @@ disabled_rules:
     - cyclomatic_complexity
     - closure_parameter_position
     - statement_position
-    - weak_delegate
     - inclusive_language
-    - class_delegate_protocol
     - legacy_cggeometry_functions
     - legacy_constructor
     - legacy_hashing

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,31 +1,6 @@
 disabled_rules:
-    - function_body_length
-    - type_body_length
     - file_length
-    - generic_type_name
-    - force_cast
-    - force_try
     - identifier_name
-    - type_name
-    - todo
-    - large_tuple
-    - unused_setter_value
-    - notification_center_detachment
-    - discarded_notification_center_observer
-    - cyclomatic_complexity
-    - closure_parameter_position
-    - statement_position
-    - inclusive_language
-    - legacy_cggeometry_functions
-    - legacy_constructor
-    - legacy_hashing
-    - multiple_closures_with_trailing_closure
-    - nesting
-    - function_parameter_count
-    - xctfail_message
-    - compiler_protocol_init
-    - reduce_boolean
-    - shorthand_operator
 
 included:
     - Sources

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,5 +12,5 @@ included:
 # the few violations. Repeat this until we find suitable limits.
 
 line_length:
-    warning: 250
-    error: 250
+    warning: 200
+    error: 200

--- a/Sources/Canvas.swift
+++ b/Sources/Canvas.swift
@@ -55,7 +55,7 @@ struct Orientation {
     }
 }
 
-public protocol CanvasDelegate {
+public protocol CanvasDelegate: AnyObject {
 
     func canvasDidChange(_ canvas: Canvas)
 
@@ -66,7 +66,7 @@ public class Canvas: UIView {
     fileprivate let minimumScale: CGFloat = 0.5
     fileprivate let maximumScale: CGFloat = 10.0
 
-    public var delegate: CanvasDelegate?
+    public weak var delegate: CanvasDelegate?
 
     /// Defines the apperance of the brush strokes when drawing
     public var brush = Brush(size: 2, color: .black)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In this PR I fixed warnings for the SwiftLint Rules below. 

- **Weak Delegate Violation**: Delegates should be weak to avoid reference cycles. `(weak_delegate)`
- **Class Delegate Protocol Violation**: Delegate protocols should be class-only so they can be weakly referenced. `(class_delegate_protocol)`

In addition to that I removed a bunch of rules from the disabled list since by having them enabled don't produce any warnings or errors.

- `function_body_length`
- `type_body_length`
- `generic_type_name`
- `force_cast`
- `force_try`
- `type_name`
- `todo`
- `large_tuple`
- `unused_setter_value`
- `notification_center_detachment`
- `discarded_notification_center_observer`
- `cyclomatic_complexity`
- `closure_parameter_position`
- `statement_position`
- `inclusive_language`
- `legacy_cggeometry_functions`
- `legacy_constructor`
- `legacy_hashing`
- `multiple_closures_with_trailing_closure`
- `nesting`
- `function_parameter_count`
- `xctfail_message`
- `compiler_protocol_init`
- `reduce_boolean`
- `shorthand_operator`


Last but not least I reduced line_length warning and error from 250 to 200 since we don't trigger any warnings or errors by having 200 as our value.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
